### PR TITLE
Fixed bug when using inputAutogrow('change')

### DIFF
--- a/src/input-autogrow.js
+++ b/src/input-autogrow.js
@@ -36,6 +36,7 @@
     this.each(function(){
       var input = $(this);
       var val = ' ';
+      options = (typeof options === 'string') ? [options] : options;
       var trailingSpace = (options && 'trailingSpace' in options) ? opts.trailingSpace : parseInt(input.css('fontSize'));
 
       var span = $('<span/>').css({


### PR DESCRIPTION
When using inputAutogrow('change') for force a re-check, options is simply a string and `line 40` causes an error because `String in String` is not valid.